### PR TITLE
use keyof any instead of PropertyKey

### DIFF
--- a/packages/blocks-testing/src/private_utils.ts
+++ b/packages/blocks-testing/src/private_utils.ts
@@ -9,7 +9,7 @@
  *
  * @hidden
  */
-export type ObjectMap<K extends PropertyKey, V> = {[P in K]: V};
+export type ObjectMap<K extends keyof any, V> = {[P in K]: V};
 
 /**
  * @hidden

--- a/packages/cli-next/src/helpers/private_utils.ts
+++ b/packages/cli-next/src/helpers/private_utils.ts
@@ -9,7 +9,7 @@
  *
  * @hidden
  */
-export type ObjectMap<K extends PropertyKey, V> = {[P in K]: V};
+export type ObjectMap<K extends keyof any, V> = {[P in K]: V};
 
 /**
  * Safely cast a value to the type passed in as a type parameter.

--- a/packages/sdk/src/private_utils.ts
+++ b/packages/sdk/src/private_utils.ts
@@ -55,7 +55,7 @@ export type ReactRefType<C> = C extends React.Component
  *
  * @hidden
  */
-export type ObjectMap<K extends PropertyKey, V> = {[P in K]: V};
+export type ObjectMap<K extends keyof any, V> = {[P in K]: V};
 
 /**
  * Creates an enum from provided string arguments.


### PR DESCRIPTION
@airtable/blocks breaks typescript if you use the keyofStringsOnly option. That can be avoided by using keyof any. If you are using keyofStringsOnly, it resolves to string, but if you not, it resolves to PropertyKey.