### PR TITLE
perf: migrate to tinyclip from clipboardy

### DIFF
--- a/packages/cli-next/package.json
+++ b/packages/cli-next/package.json
@@ -19,7 +19,6 @@
         "archiver": "^5.1.0",
         "chalk": "^4.1.0",
         "cli-ux": "^5.5.1",
-        "clipboardy": "^2.3.0",
         "cpx2": "7.0.1",
         "cross-spawn": "^7.0.3",
         "debug": "^4.2.0",
@@ -29,6 +28,7 @@
         "http-proxy-middleware": "^3.0.3",
         "strip-ansi": "^6.0.0",
         "tar": "^6.1.0",
+        "tinyclip": "^0.1.12",
         "tslib": "^1.14.1",
         "typescript": "^5.4.5"
     },
@@ -76,7 +76,7 @@
         "which": "^2.0.2"
     },
     "engines": {
-        "node": ">=10.0.0"
+        "node": ">=16.4.0"
     },
     "files": [
         "/bin",

--- a/packages/cli-next/src/commands/run.ts
+++ b/packages/cli-next/src/commands/run.ts
@@ -1,6 +1,6 @@
 import {flags as commandFlags} from '@oclif/command';
 import _debug from 'debug';
-import clipboardy from 'clipboardy';
+import { writeText } from 'tinyclip';
 import chalk from 'chalk';
 
 import AirtableCommand from '../helpers/airtable_command';
@@ -297,7 +297,7 @@ export default class Run extends AirtableCommand {
 
         try {
             await Promise.race([
-                clipboardy.write(`https://localhost:${secureServerPort}`),
+                writeText(`https://localhost:${secureServerPort}`),
                 appConfigModifiedPromise,
             ]);
             this.log(`https://localhost:${secureServerPort} has been copied to your clipboard`);


### PR DESCRIPTION
Tinyclip is [really lighter](https://npmx.dev/compare?packages=tinyclip,clipboardy) than clipboardy. This PR was made as part of the [e18e initiative](https://e18e.dev/).

This likely requires a major because of the node constraint change. Also, I wasn't able to update `yarn.lock` because there's a dependency on a private package